### PR TITLE
#4 탐색 페이지 UI 구현

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import Header from '@common/Header';
 import GlobalStyle from '@style/GlobalStyle';
 import NewFeedContainer from '@newFeed/container/NewFeedContainer';
+import FeedExploreContainer from '@feedExplore/container/FeedExploreContainer';
 import pathURI from '@constants/path';
 
 const style = {};
@@ -28,6 +29,11 @@ const App = () => {
         <style.RouteWrapper>
           <Switch>
             <Route exact path={pathURI.NEWFEED} component={NewFeedContainer} />
+            <Route
+              exact
+              path={pathURI.FEEDEXPLORE}
+              component={FeedExploreContainer}
+            />
           </Switch>
         </style.RouteWrapper>
       </style.Contents>

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -31,7 +31,7 @@ const App = () => {
             <Route exact path={pathURI.NEWFEED} component={NewFeedContainer} />
             <Route
               exact
-              path={pathURI.FEEDEXPLORE}
+              path={pathURI.EXPLORE}
               component={FeedExploreContainer}
             />
           </Switch>

--- a/client/src/components/feedExplore/container/FeedExploreContainer.js
+++ b/client/src/components/feedExplore/container/FeedExploreContainer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import FeedList from '@feedExplore/presentational/FeedList';
 
 const style = {};
 
@@ -8,9 +9,11 @@ style.FeedExploreContainer = styled.div`
   border: 1px solid red;
 `;
 
+const dummy = [];
+
 const FeedExploreContainer = () => (
   <style.FeedExploreContainer>
-    <div>아무거나</div>
+    <FeedList datas={dummy} />
   </style.FeedExploreContainer>
 );
 

--- a/client/src/components/feedExplore/container/FeedExploreContainer.js
+++ b/client/src/components/feedExplore/container/FeedExploreContainer.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const style = {};
+
+style.FeedExploreContainer = styled.div`
+  margin: 0 auto;
+  border: 1px solid red;
+`;
+
+const FeedExploreContainer = () => (
+  <style.FeedExploreContainer>
+    <div>아무거나</div>
+  </style.FeedExploreContainer>
+);
+
+export default FeedExploreContainer;

--- a/client/src/components/feedExplore/presentational/FeedCard.js
+++ b/client/src/components/feedExplore/presentational/FeedCard.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const style = {};
+
+style.FeedCard = styled.article`
+  height: 292.99px;
+  width: 292.99px;
+  margin-top: 28.01px;
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+`;
+
+style.ImgBox = styled.img`
+  max-width: 100%;
+  height: auto;
+  display: block;
+  opacity: 1;
+`;
+
+const FeedCard = (input) => {
+  const { imgUrl } = input.data;
+
+  return (
+    <>
+      <style.FeedCard>
+        <style.ImgBox src={imgUrl[0]} />
+      </style.FeedCard>
+    </>
+  );
+};
+
+export default FeedCard;

--- a/client/src/components/feedExplore/presentational/FeedCard.js
+++ b/client/src/components/feedExplore/presentational/FeedCard.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 const style = {};
@@ -12,20 +12,68 @@ style.FeedCard = styled.article`
   cursor: pointer;
 `;
 
+style.iconImg = styled.img`
+  height: 15px;
+  width: 15px;
+  margin: auto 0;
+`;
+
+style.number = styled.div`
+  margin: auto 0;
+`;
+
 style.ImgBox = styled.img`
   max-width: 100%;
   height: auto;
   display: block;
-  opacity: 1;
+  opacity: ${(props) => (props.hover ? 0.3 : 1)};
+`;
+
+style.icon = styled.div`
+  opacity: ${(props) => {
+    console.log(props);
+    return props.hover ? 1 : 0;
+  }};
+  display: flex;
+  text-align: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 `;
 
 const FeedCard = (input) => {
-  const { imgUrl } = input.data;
+  const { feedImg, like, comments } = input.data;
+  const [hover, setHover] = useState(false);
+  const likeIcon =
+    'https://user-images.githubusercontent.com/39620410/100316277-82a4c580-2ffd-11eb-8f22-704e6cb6d29f.png';
+  const likeNum = like.length;
+  const commentIcon =
+    'https://user-images.githubusercontent.com/39620410/100316277-82a4c580-2ffd-11eb-8f22-704e6cb6d29f.png';
+  const commentNum = comments.length;
 
+  const hoverHandler = () => {
+    setHover(!hover);
+  };
+
+  const clickHandler = () => {
+    // todo: 상세 화면 출력
+  };
   return (
     <>
-      <style.FeedCard>
-        <style.ImgBox src={imgUrl[0]} />
+      <style.FeedCard
+        onMouseEnter={hoverHandler}
+        onMouseLeave={hoverHandler}
+        onClick={clickHandler}
+      >
+        <style.ImgBox src={feedImg[0]} hover={hover} />
+        <style.icon hover={hover}>
+          <style.iconImg src={likeIcon} />
+          <style.number>{likeNum}</style.number>
+          <style.iconImg src={commentIcon} />
+          <style.number>{commentNum}</style.number>
+        </style.icon>
       </style.FeedCard>
     </>
   );

--- a/client/src/components/feedExplore/presentational/FeedList.js
+++ b/client/src/components/feedExplore/presentational/FeedList.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from 'styled-components';
+import FeedCard from './FeedCard';
+
+const style = {};
+
+style.FeedList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+`;
+
+const FeedList = (input) => {
+  const { datas } = input;
+  return (
+    <style.FeedList>
+      {datas.map((data, index) => {
+        return <FeedCard data={data} key={index} />;
+      })}
+    </style.FeedList>
+  );
+};
+
+export default FeedList;

--- a/client/src/constants/path.js
+++ b/client/src/constants/path.js
@@ -1,6 +1,7 @@
 const pathURI = {
   HOME: '/',
   NEWFEED: '/newFeed',
+  FEEDEXPLORE: '/explore',
 };
 
 export default pathURI;

--- a/client/src/constants/path.js
+++ b/client/src/constants/path.js
@@ -1,7 +1,7 @@
 const pathURI = {
   HOME: '/',
   NEWFEED: '/newFeed',
-  FEEDEXPLORE: '/explore',
+  EXPLORE: '/explore',
 };
 
 export default pathURI;

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -44,6 +44,7 @@ module.exports = {
       '@common': path.resolve(__dirname, 'src/components/common/'),
       '@style': path.resolve(__dirname, 'src/components/style/'),
       '@newFeed': path.resolve(__dirname, 'src/components/newFeed/'),
+      '@feedExplore': path.resolve(__dirname, 'src/components/feedExplore/'),
       '@constants': path.resolve(__dirname, 'src/constants/'),
     },
   },


### PR DESCRIPTION
### 제목
- #4 탐색 페이지 UI 구현

### 구현내용
- explore 컴포넌트 (모든 게시물 조회) 구현
- 한 열에 3개의 게시물 출력
- 게시물 출력 시 해당 게시물의 좋아요 / 코멘트 수 정보 출력
- dummy data 사용
- 아이콘 위치 등 수정 예정

### 체크리스트
- [x] dev 브랜치가 맞는가?
- [ ] issue를 잘 닫았는가?
- [x] reviewer, assignee, label 등록을 했는가?
