### PR TITLE
#6 - 탐색 페이지 조회 API 구현

### DIFF
--- a/server/src/controllers/feed.controller.ts
+++ b/server/src/controllers/feed.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import feedService from '../services/feed.service';
+import { create, explore } from '../services/feed.service';
 
 interface callback {
   [key: string]: (req: Request, res: Response) => void;
@@ -7,20 +7,34 @@ interface callback {
 const feedController: callback = {};
 
 feedController.create = async (req: Request, res: Response) => {
-  const { feedImg, author } = req.body;
-  if (!(feedImg.length !== 0 && author)) {
-    return res.status(400).end();
-  }
-  const success = await feedService.create(req.body);
-  if (success) {
-    return res.status(201).end();
-  }
+  const params = {
+    author: undefined,
+    content: req.body.content,
+    location: req.body.location,
+    like: undefined,
+    feedImg: undefined,
+    comments: undefined,
+  };
+
+  if (req.body.author) params.author = JSON.parse(req.body.author);
+  else return res.status(400).end();
+
+  if (req.body.feedImg) params.feedImg = JSON.parse(req.body.feedImg);
+  else return res.status(400).end();
+
+  if (req.body.like) params.like = JSON.parse(req.body.like);
+
+  if (req.body.comments) params.comments = JSON.parse(req.body.comments);
+
+  const success = await create(params);
+  if (success) return res.status(201).end();
+
   return res.status(400).end();
 };
 
 feedController.explore = async (req: Request, res: Response) => {
-  const success = await feedService.explore(req.body);
-  if (success) return res.status(201).end();
+  const result = await explore();
+  if (result) return res.status(201).json(result).end();
   return res.status(400).end();
 };
 

--- a/server/src/controllers/feed.controller.ts
+++ b/server/src/controllers/feed.controller.ts
@@ -18,4 +18,10 @@ feedController.create = async (req: Request, res: Response) => {
   return res.status(400).end();
 };
 
+feedController.explore = async (req: Request, res: Response) => {
+  const success = await feedService.explore(req.body);
+  if (success) return res.status(201).end();
+  return res.status(400).end();
+};
+
 export default feedController;

--- a/server/src/models/feed.model.ts
+++ b/server/src/models/feed.model.ts
@@ -10,6 +10,13 @@ const author = new mongoose.Schema({
   profileImg: String,
 });
 
+export interface Iauthor {
+  userId: mongoose.Schema.Types.ObjectId;
+  name: string;
+  userName: string;
+  profileImg: string;
+}
+
 const comment = new mongoose.Schema(
   {
     _id: {
@@ -24,7 +31,15 @@ const comment = new mongoose.Schema(
   { timestamps: true },
 );
 
-const FeedSchema = new mongoose.Schema(
+export interface Icomment {
+  _id: mongoose.Schema.Types.ObjectId;
+  parentId: mongoose.Schema.Types.ObjectId;
+  author: Iauthor;
+  content: string;
+  like: Array<Iauthor>;
+}
+
+const Feed = new mongoose.Schema(
   {
     author,
     content: String,
@@ -36,18 +51,26 @@ const FeedSchema = new mongoose.Schema(
   { timestamps: true },
 );
 
-FeedSchema.methods.createFeed = async function createFeed() {
-  try {
-    const result = await mongoose.model('Feed').create(this);
-    return result;
-  } catch (err) {
-    return false;
-  }
+Feed.methods.createFeed = async function createFeed() {
+  const result = await mongoose.model('Feed').create(this);
+  return result;
 };
 
-type boolFunc = () => boolean;
-interface FeedInterface extends mongoose.Document {
-  createFeed: boolFunc;
+Feed.methods.exploreFeed = async function exploreFeed() {
+  const result = await mongoose.model('Feed').find();
+  return result;
+};
+
+export interface IFeed extends mongoose.Document {
+  author: Iauthor;
+  content?: string;
+  location?: string;
+  like?: Array<Iauthor>;
+  feedImg: Array<string>;
+  comments?: Array<Icomment>;
+
+  createFeed: () => boolean;
+  exploreFeed: () => Array<IFeed>;
 }
 
-export = mongoose.model<FeedInterface>('Feed', FeedSchema);
+export default mongoose.model<IFeed>('Feed', Feed);

--- a/server/src/models/feed.model.ts
+++ b/server/src/models/feed.model.ts
@@ -1,14 +1,17 @@
 import mongoose from 'mongoose';
 
-const author = new mongoose.Schema({
-  userId: {
-    type: mongoose.Schema.Types.ObjectId,
-    required: true,
+const author = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+    },
+    name: String,
+    userName: String,
+    profileImg: String,
   },
-  name: String,
-  userName: String,
-  profileImg: String,
-});
+  { _id: false },
+);
 
 export interface Iauthor {
   userId: mongoose.Schema.Types.ObjectId;

--- a/server/src/models/init.model.ts
+++ b/server/src/models/init.model.ts
@@ -65,6 +65,7 @@ function seedData(): void {
           'https://ca.slack-edge.com/T019JFET9H7-U019PN65926-7d7d0974a7f9-512',
       },
       content: 'yageunjoa',
+      location: '',
       feedImg: [
         'https://avatars0.githubusercontent.com/u/24909656?s=460&u=d41305b6b314f0232605a0f9f293da5f40319199&v=4',
       ],
@@ -78,6 +79,7 @@ function seedData(): void {
           'https://ca.slack-edge.com/T019JFET9H7-U01AE19CWUQ-ccf648c8636a-512',
       },
       content: 'yageunsireo',
+      location: '',
       feedImg: [
         'https://ca.slack-edge.com/T019JFET9H7-U01AE19CWUQ-ccf648c8636a-512',
       ],
@@ -91,6 +93,7 @@ function seedData(): void {
           'https://ca.slack-edge.com/T019JFET9H7-U019GGE0086-9b1c9fa14e8b-512',
       },
       content: 'yageunsireo',
+      location: '',
       feedImg: [
         'https://ca.slack-edge.com/T019JFET9H7-U019GGE0086-9b1c9fa14e8b-512',
       ],

--- a/server/src/routes/feed.router.ts
+++ b/server/src/routes/feed.router.ts
@@ -5,4 +5,6 @@ const router = express.Router();
 
 router.post('/', feedController.create);
 
+router.get('/explore', feedController.explore);
+
 export default router;

--- a/server/src/services/feed.service.ts
+++ b/server/src/services/feed.service.ts
@@ -1,27 +1,24 @@
-import FeedModel from '../models/feed.model';
+import FeedModel, { IFeed } from '../models/feed.model';
 
-interface createParams {
-  feedImg: Array<string>;
-  content: string;
-  location: string;
-  tag: string;
-  author: string;
+interface IcreateParam {
+  author?: Record<string, unknown>;
+  content?: string;
+  location?: string;
+  like?: [];
+  feedImg?: [];
+  comments?: [];
 }
-type feedServiceType = (params: createParams) => Promise<boolean>;
-interface callback {
-  [key: string]: feedServiceType;
-}
-const feedService: callback = {};
 
-feedService.create = async (params: createParams) => {
-  const doc = new FeedModel(params);
-  const success = await doc.createFeed();
-  if (success) {
-    return true;
-  }
-  return false;
+const create = async (params: IcreateParam): Promise<boolean> => {
+  const feed = new FeedModel(params);
+  const result = await feed.createFeed();
+  return result;
 };
 
-feedService.explore = async () => true;
+const explore = async (): Promise<IFeed[]> => {
+  const feed = new FeedModel();
+  const result = feed.exploreFeed();
+  return result;
+};
 
-export default feedService;
+export { create, explore };

--- a/server/src/services/feed.service.ts
+++ b/server/src/services/feed.service.ts
@@ -22,4 +22,6 @@ feedService.create = async (params: createParams) => {
   return false;
 };
 
+feedService.explore = async () => true;
+
 export default feedService;


### PR DESCRIPTION
#6 

### 구현 내용
- feed 및 feed 내 author, comments 인터페이스 생성
- feed model 안에 feed 생성 및 탐색 메소드 구현
- controller에서 body parsing 후 인터페이스에 맞게 변환
- seeding data에 location 추가

### 체크리스트
- [x] dev 브랜치가 맞는가?
- [ ] issue를 잘 닫았는가?
- [x] reviewer, assignee, label 등록을 했는가?
