### PR TITLE
#43 홈 화면 조회 API 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1862,6 +1862,39 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2441,6 +2474,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
     },
     "core-js-compat": {
       "version": "3.7.0",

--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "cross-env": "^7.0.2",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",

--- a/client/src/components/home/container/HomeContainer.js
+++ b/client/src/components/home/container/HomeContainer.js
@@ -18,32 +18,24 @@ const HomeContainer = () => {
   const [loading, setLoading] = useState(false);
   // const user = useContext(userContext);
   const userId = '5fc73c8d690808276cab1a88';
-  console.log('1');
   const getData = () => {
     const url = pathURL.IP + pathURL.API_HOME_FEED + userId;
-    console.log(url);
     const option = {
       mode: 'cors',
       method: 'GET',
     };
-    console.log('2');
     async function fetchUrl() {
       const response = await fetch(url, option);
       const json = await response.json();
-      console.log('2.5');
       setData(json);
       setLoading(true);
     }
     useEffect(() => {
-      console.log('?');
       fetchUrl();
     }, []);
   };
-  console.log('3');
   getData();
-  console.log('4');
   if (loading) {
-    console.log(loading);
     return (
       <style.HomeContainer>
         <Contents data={data} />
@@ -51,7 +43,6 @@ const HomeContainer = () => {
       </style.HomeContainer>
     );
   }
-  console.log('!');
   return <>loading...</>;
 };
 

--- a/client/src/components/home/container/HomeContainer.js
+++ b/client/src/components/home/container/HomeContainer.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import Side from '@home/presentational/Side';
 import Contents from '@home/presentational/Contents';
+import pathURL from '@constants/path';
 
 const style = {};
 
@@ -13,12 +14,45 @@ style.HomeContainer = styled.div`
   margin-top: 30px;
 `;
 const HomeContainer = () => {
-  return (
-    <style.HomeContainer>
-      <Contents />
-      <Side />
-    </style.HomeContainer>
-  );
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(false);
+  // const user = useContext(userContext);
+  const userId = '5fc73c8d690808276cab1a88';
+  console.log('1');
+  const getData = () => {
+    const url = pathURL.IP + pathURL.API_HOME_FEED + userId;
+    console.log(url);
+    const option = {
+      mode: 'cors',
+      method: 'GET',
+    };
+    console.log('2');
+    async function fetchUrl() {
+      const response = await fetch(url, option);
+      const json = await response.json();
+      console.log('2.5');
+      setData(json);
+      setLoading(true);
+    }
+    useEffect(() => {
+      console.log('?');
+      fetchUrl();
+    }, []);
+  };
+  console.log('3');
+  getData();
+  console.log('4');
+  if (loading) {
+    console.log(loading);
+    return (
+      <style.HomeContainer>
+        <Contents data={data} />
+        <Side />
+      </style.HomeContainer>
+    );
+  }
+  console.log('!');
+  return <>loading...</>;
 };
 
 export default HomeContainer;

--- a/client/src/components/home/presentational/Contents.js
+++ b/client/src/components/home/presentational/Contents.js
@@ -11,11 +11,12 @@ style.Contents = styled.div`
   max-width: 614px;
 `;
 
-const Contents = () => {
+const Contents = (input) => {
+  const { data } = input;
   return (
     <style.Contents>
       <Story />
-      <Feed />
+      <Feed data={data} />
     </style.Contents>
   );
 };

--- a/client/src/components/home/presentational/Feed.js
+++ b/client/src/components/home/presentational/Feed.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
-import dummy from '@feedExplore/dummy';
+// import dummy from '@feedExplore/dummy';
 import FeedItem from '@home/presentational/FeedItem';
 
 const style = {};
 
 style.Feed = styled.div``;
 
-const Feed = () => {
+const Feed = (input) => {
+  const { data: dummy } = input;
   return (
     <style.Feed>
       {dummy.map((data) => {

--- a/client/src/constants/path.js
+++ b/client/src/constants/path.js
@@ -5,6 +5,7 @@ const pathURI = {
   API_NEWFEED: '/feed',
   EXPLORE: '/explore',
   IMG_UPLOAD: '/image',
+  API_HOME_FEED: '/feed/following/',
 };
 
 export default pathURI;

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -5,7 +5,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 module.exports = {
   mode: process.env.NODE_ENV,
   entry: {
-    main: './src/index.js',
+    app: ['babel-polyfill', './src/index.js'],
   },
   output: {
     path: path.resolve('./dist'),

--- a/server/src/controllers/feed.controller.ts
+++ b/server/src/controllers/feed.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
-import { create, explore } from '../services/feed.service';
+import mongoose from 'mongoose';
+import { create, explore, following } from '../services/feed.service';
 
 interface callback {
   [key: string]: (req: Request, res: Response) => void;
@@ -20,6 +21,22 @@ feedController.create = async (req: Request, res: Response) => {
 
 feedController.explore = async (req: Request, res: Response) => {
   const result = await explore();
+  if (result) return res.status(200).json(result);
+  return res.status(500).end();
+};
+
+feedController.following = async (req: Request, res: Response) => {
+  const { userid } = req.params;
+  const user = await mongoose
+    .model('User')
+    .findOne({ email: 'rlaqudrnr810@gmail.com' });
+  // const user = await mongoose
+  //   .model('User')
+  //   .findOne({ _id: userid });
+  if (!user) {
+    return res.status(400).end();
+  }
+  const result = await following(user);
   if (result) return res.status(200).json(result);
   return res.status(500).end();
 };

--- a/server/src/models/feed.model.ts
+++ b/server/src/models/feed.model.ts
@@ -64,6 +64,15 @@ Feed.methods.exploreFeed = async function exploreFeed() {
   return result;
 };
 
+Feed.methods.followingFeed = async function followingFeed(
+  params: Array<string>,
+) {
+  const result = await mongoose
+    .model('Feed')
+    .find({ 'author.userId': { $in: params } });
+  return result;
+};
+
 export interface IFeed extends mongoose.Document {
   author: Iauthor;
   content?: string;
@@ -74,6 +83,7 @@ export interface IFeed extends mongoose.Document {
 
   createFeed: () => boolean;
   exploreFeed: () => Array<IFeed>;
+  followingFeed: (params: Array<string>) => Array<IFeed>;
 }
 
 export default mongoose.model<IFeed>('Feed', Feed);

--- a/server/src/models/init.model.ts
+++ b/server/src/models/init.model.ts
@@ -51,6 +51,26 @@ function seedData(): void {
       password: '1q2w3e4r!@',
       profileImg:
         'https://ca.slack-edge.com/T019JFET9H7-U019GGE0086-9b1c9fa14e8b-512',
+      follow: [
+        {
+          userId: '5fbf7104e5213064cc2ffae7',
+          name: '123',
+          userName: '123123',
+          profileImg: '123123123',
+        },
+        {
+          userId: '5fbf7104e5213064cc2ffae8',
+          name: '123',
+          userName: '123123',
+          profileImg: '123123123',
+        },
+        {
+          userId: '5fbf7104e5213064cc2ffae9',
+          name: '123',
+          userName: '123123',
+          profileImg: '123123123',
+        },
+      ],
     },
   ]);
 

--- a/server/src/models/user.model.ts
+++ b/server/src/models/user.model.ts
@@ -33,4 +33,37 @@ const userSchema = new mongoose.Schema({
   notiContents,
 });
 
-export default mongoose.model('User', userSchema);
+export interface IFollow {
+  userId?: mongoose.Schema.Types.ObjectId;
+  name?: string;
+  userName?: string;
+  profileImg?: string;
+}
+
+export interface InotiOptions {
+  like: string;
+  comment: string;
+  commentLike: string;
+}
+
+export interface InotiContents {
+  userId: mongoose.Schema.Types.ObjectId;
+  profileImg: string;
+  userName: string;
+  notiType: string;
+  date: string;
+}
+
+export interface IUser extends mongoose.Document {
+  name?: string;
+  userName?: string;
+  email?: string;
+  password?: string;
+  profileImg?: string;
+  follow?: Array<IFollow>;
+  follower?: Array<IFollow>;
+  notiOptions?: InotiOptions;
+  notiContents?: InotiContents;
+}
+
+export default mongoose.model<IUser>('User', userSchema);

--- a/server/src/routes/feed.router.ts
+++ b/server/src/routes/feed.router.ts
@@ -7,4 +7,6 @@ router.post('/', feedController.create);
 
 router.get('/explore', feedController.explore);
 
+router.get('/following/:userid', feedController.following);
+
 export default router;

--- a/server/src/services/feed.service.ts
+++ b/server/src/services/feed.service.ts
@@ -1,4 +1,5 @@
 import FeedModel, { IFeed } from '../models/feed.model';
+import { IUser } from '../models/user.model';
 
 const create = async (params: IFeed): Promise<boolean> => {
   const feed = new FeedModel(params);
@@ -12,4 +13,17 @@ const explore = async (): Promise<IFeed[]> => {
   return result;
 };
 
-export { create, explore };
+const following = async (params: IUser) => {
+  const { follow: follows } = params;
+  const userFollow: string[] = [];
+  follows?.map((follow) => {
+    if (follow.userId) {
+      userFollow.push(follow.userId.toString());
+    }
+  });
+  const feed = new FeedModel();
+  const result = feed.followingFeed(userFollow);
+  return result;
+};
+
+export { create, explore, following };


### PR DESCRIPTION
#43 

### 내용
- 홈 화면에서 사용할 api 구현
- 내가 follow한 유저들의 게시물만 조회
- 서버 작동 시 기존의 id값 초기화 이슈로 인해 현재는 email정보를 이용해 follow 리스트 탐색
- api 정상 동작 확인 후 client에 적용
- src/home/container/HomeContainer에서 데이터 fetch 후 컴포넌트에 전달하는 로직 구현
- cors 이슈로 인해 webpack 설정 수정

![image](https://user-images.githubusercontent.com/39620410/100881395-396adf00-34f1-11eb-9b93-f4ab78ce9815.png)


### 체크리스트
- [ ] dev 브랜치가 맞는가?
- [ ] issue를 잘 닫았는가?
- [ ] reviewer, assignee, label 등록을 했는가?
