### PR TITLE
feat: 사용자 이름에 맞는 프로필 페이지 구현

### DIFF
--- a/client/src/components/profile/container/ProfileContainer.js
+++ b/client/src/components/profile/container/ProfileContainer.js
@@ -9,9 +9,9 @@ const style = {};
 
 style.ProfileContainer = styled.div``;
 
-const ProfileContainer = () => {
-  const { login } = useContext(UserContext);
-  const { userName } = login;
+const ProfileContainer = (props) => {
+  let userName = props.location.search.split('=')[1];
+  if (!userName) userName = useContext(UserContext).login.userName;
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
   const getData = () => {

--- a/client/src/components/profile/container/ProfileContainer.js
+++ b/client/src/components/profile/container/ProfileContainer.js
@@ -23,6 +23,7 @@ const ProfileContainer = () => {
     async function fetchUrl() {
       const response = await fetch(url, option);
       const json = await response.json();
+      json.feeds.reverse();
       setData(json);
       setLoading(true);
     }
@@ -35,7 +36,7 @@ const ProfileContainer = () => {
     return (
       <style.ProfileContainer>
         <ProfileInfo data={data} />
-        <FeedList datas={data.feeds.reverse()} />
+        <FeedList datas={data.feeds} />
       </style.ProfileContainer>
     );
   }

--- a/client/src/components/profile/container/ProfileContainer.js
+++ b/client/src/components/profile/container/ProfileContainer.js
@@ -10,8 +10,9 @@ const style = {};
 style.ProfileContainer = styled.div``;
 
 const ProfileContainer = (props) => {
+  const { login } = useContext(UserContext);
   let userName = props.location.search.split('=')[1];
-  if (!userName) userName = useContext(UserContext).login.userName;
+  if (!userName) userName = login.userName;
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
   const getData = () => {
@@ -24,6 +25,7 @@ const ProfileContainer = (props) => {
       const response = await fetch(url, option);
       const json = await response.json();
       json.feeds.reverse();
+      json.login = login;
       setData(json);
       setLoading(true);
     }

--- a/client/src/components/profile/presentational/ProfileInfo.js
+++ b/client/src/components/profile/presentational/ProfileInfo.js
@@ -81,16 +81,56 @@ style.UserName = styled.div`
   margin-top: 20px;
 `;
 
+style.FollowBtn = styled.div`
+  background-color: #0095f6;
+  border: none;
+  border-radius: 3px;
+  color: white;
+  font-weight: bold;
+  padding: 4px 20px;
+`;
+
+style.UnfollowBtn = styled.div`
+  background-color: transparent;
+  border: 1px solid ${theme.color.border};
+  border-radius: 3px;
+  font-weight: bold;
+  padding: 4px 20px;
+`;
+
 const ProfileInfo = (props) => {
-  const { userInfo, feeds } = props.data;
+  const { userInfo, feeds, login } = props.data;
+
+  const checkFollowing = () => {
+    let result = false;
+    userInfo.follower.forEach((el) => {
+      if (el.userName === login.userName) {
+        result = true;
+      }
+    });
+    return result;
+  };
+
+  const FollowOrUnfollow = checkFollowing() ? (
+    <style.UnfollowBtn>언팔로우</style.UnfollowBtn>
+  ) : (
+    <style.FollowBtn>팔로우</style.FollowBtn>
+  );
+
   return (
     <style.ProfileInfo>
       <style.ProfileImg src={userInfo.profileImg} />
       <style.ProfileDetail>
         <style.NameAndSettings>
           <style.Name>{userInfo.userName}</style.Name>
-          <style.ChangeProfile>프로필 편집</style.ChangeProfile>
-          <icon.Setting />
+          {login.userName === userInfo.userName ? (
+            <>
+              <style.ChangeProfile>프로필 편집</style.ChangeProfile>
+              <icon.Setting />
+            </>
+          ) : (
+            FollowOrUnfollow
+          )}
         </style.NameAndSettings>
         <style.FeedAndFollow>
           <style.FeedCountTitle>게시물</style.FeedCountTitle>


### PR DESCRIPTION
### 구현 내용
- 프로필 페이지에서 쿼리로 넘어온 사용자의 프로필 표시
- 팔로우 중인 사용자 / 팔로우하지 않은 사용자 / 본인 프로필 분기 처리

### 체크리스트
- [x] dev 브랜치가 맞는가?
- [x] issue를 잘 닫았는가?
- [x] reviewer, assignee, label 등록을 했는가?
