### PR TITLE
#135 사용자 팔로우/언팔로우

### DIFF
--- a/client/src/components/profile/presentational/ProfileInfo.js
+++ b/client/src/components/profile/presentational/ProfileInfo.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import theme from '@style/Theme';
 import icon from '@constants/icon';
+import pathURI from '@constants/path';
 
 const style = {};
 
@@ -88,6 +89,7 @@ style.FollowBtn = styled.div`
   color: white;
   font-weight: bold;
   padding: 4px 20px;
+  cursor: pointer;
 `;
 
 style.UnfollowBtn = styled.div`
@@ -96,10 +98,11 @@ style.UnfollowBtn = styled.div`
   border-radius: 3px;
   font-weight: bold;
   padding: 4px 20px;
+  cursor: pointer;
 `;
 
-const ProfileInfo = (props) => {
-  const { userInfo, feeds, login } = props.data;
+const ProfileInfo = (input) => {
+  const { userInfo, feeds, login } = input.data;
 
   const checkFollowing = () => {
     let result = false;
@@ -110,11 +113,36 @@ const ProfileInfo = (props) => {
     });
     return result;
   };
-
-  const FollowOrUnfollow = checkFollowing() ? (
-    <style.UnfollowBtn>언팔로우</style.UnfollowBtn>
+  const [followStatus, setFollowState] = useState(checkFollowing());
+  const [followNum, setFollowNumState] = useState(userInfo.follow.length);
+  const [followerNum, setFollowerNumState] = useState(userInfo.follower.length);
+  const clickHandler = () => {
+    const { name, userName, profileImg } = login;
+    const followData = {
+      author: {
+        name,
+        userName,
+        profileImg,
+      },
+      status: followStatus ? 0 : 1,
+    };
+    fetch(pathURI.IP + pathURI.API_FOLLOW + userInfo.userName, {
+      mode: 'cors',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${login.jwt}`,
+      },
+      body: JSON.stringify(followData),
+    }).then(() => {
+      setFollowerNumState(followStatus ? followerNum - 1 : followerNum + 1);
+      setFollowState(!followStatus);
+    });
+  };
+  const FollowOrUnfollow = followStatus ? (
+    <style.UnfollowBtn onClick={clickHandler}>언팔로우</style.UnfollowBtn>
   ) : (
-    <style.FollowBtn>팔로우</style.FollowBtn>
+    <style.FollowBtn onClick={clickHandler}>팔로우</style.FollowBtn>
   );
 
   return (
@@ -136,13 +164,9 @@ const ProfileInfo = (props) => {
           <style.FeedCountTitle>게시물</style.FeedCountTitle>
           <style.FeedCountDetail>{feeds.length}</style.FeedCountDetail>
           <style.FollowerTitle>팔로워</style.FollowerTitle>
-          <style.FollowerDetail>
-            {userInfo.follower.length}
-          </style.FollowerDetail>
+          <style.FollowerDetail>{followerNum}</style.FollowerDetail>
           <style.FollowingTitle>팔로우</style.FollowingTitle>
-          <style.FollowingDetail>
-            {userInfo.follow.length}
-          </style.FollowingDetail>
+          <style.FollowingDetail>{followNum}</style.FollowingDetail>
         </style.FeedAndFollow>
         <style.UserName>{userInfo.name}</style.UserName>
       </style.ProfileDetail>

--- a/client/src/constants/path.js
+++ b/client/src/constants/path.js
@@ -11,6 +11,7 @@ const common = {
   API_EXPLORE: '/feed/explore/',
   API_COMMENT: '/comment/',
   API_LIKE: '/feed/like/',
+  API_FOLLOW: '/user/follow/',
 };
 
 let IP = 'http://localhost:3000';

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
-import getProfile from '../services/user.service';
+import { getProfile, follow } from '../services/user.service';
+import getUserId from '../lib/getUserId';
 
 interface callback {
   [key: string]: (req: Request, res: Response) => void;
@@ -10,6 +11,21 @@ const UserController: callback = {};
 UserController.getProfile = async (req, res) => {
   const result = await getProfile(req.params.userName);
   res.json(result);
+};
+
+UserController.follow = async (req, res) => {
+  const { author, status } = req.body;
+  const { userName } = req.params;
+  const { user } = req;
+
+  author.userId = getUserId(user);
+  if (!(author && userName && (status === 0 || status === 1))) {
+    return res.status(400).end();
+  }
+  const success = await follow(author, userName, status);
+  if (success) return res.status(201).json({ messege: 'success' });
+
+  return res.status(500).end();
 };
 
 export default UserController;

--- a/server/src/models/user.model.ts
+++ b/server/src/models/user.model.ts
@@ -68,6 +68,68 @@ export interface InotiContents {
   date: string;
 }
 
+userSchema.methods.createFollow = async function createfollow(
+  user: IFollow,
+  target: IFollow,
+) {
+  const result =
+    (await mongoose.model('User').updateOne(
+      { _id: user.userId },
+      {
+        $push: {
+          follow: {
+            userId: target.userId,
+            name: target.name,
+            userName: target.userName,
+            profileImg: target.profileImg,
+          },
+        },
+      },
+    )) &&
+    (await mongoose.model('User').updateOne(
+      { _id: target.userId },
+      {
+        $push: {
+          follower: {
+            userId: user.userId,
+            name: user.name,
+            userName: user.userName,
+            profileImg: user.profileImg,
+          },
+        },
+      },
+    ));
+  return result;
+};
+
+userSchema.methods.deleteFollow = async function deletefollow(
+  user: IFollow,
+  target: IFollow,
+) {
+  const result =
+    (await mongoose.model('User').updateOne(
+      { _id: user.userId },
+      {
+        $pull: {
+          follow: {
+            userId: target.userId,
+          },
+        },
+      },
+    )) &&
+    (await mongoose.model('User').updateOne(
+      { _id: target.userId },
+      {
+        $pull: {
+          follower: {
+            userId: user.userId,
+          },
+        },
+      },
+    ));
+  return result;
+};
+
 export interface IUser extends mongoose.Document {
   name?: string;
   userName: string;
@@ -80,6 +142,8 @@ export interface IUser extends mongoose.Document {
   notiContents?: InotiContents;
   createUser: () => any;
   findUserName: () => any;
+  createFollow: (user: IFollow, target: IFollow) => boolean;
+  deleteFollow: (user: IFollow, target: IFollow) => boolean;
 }
 
 export default mongoose.model<IUser>('User', userSchema);

--- a/server/src/models/user.model.ts
+++ b/server/src/models/user.model.ts
@@ -109,29 +109,28 @@ userSchema.methods.deleteFollow = async function deletefollow(
   user: IFollow,
   target: IFollow,
 ) {
-  console.log(target);
-  console.log(user);
-  const result = await mongoose.model('User').updateOne(
-    { _id: user.userId },
-    {
-      $pull: {
-        follow: {
-          userId: target.userId,
+  const result =
+    (await mongoose.model('User').updateOne(
+      { _id: user.userId },
+      {
+        $pull: {
+          follow: {
+            userId: target.userId,
+          },
         },
       },
-    },
-  );
-  const result1 = await mongoose.model('User').updateOne(
-    { _id: target.userId },
-    {
-      $pull: {
-        follower: {
-          userId: user.userId,
+    )) &&
+    (await mongoose.model('User').updateOne(
+      { _id: target.userId },
+      {
+        $pull: {
+          follower: {
+            userId: user.userId,
+          },
         },
       },
-    },
-  );
-  return result && result1;
+    ));
+  return result;
 };
 
 export interface IUser extends mongoose.Document {

--- a/server/src/models/user.model.ts
+++ b/server/src/models/user.model.ts
@@ -14,12 +14,15 @@ const notiContents = new mongoose.Schema({
   date: String,
 });
 
-const followSchema = new mongoose.Schema({
-  userId: mongoose.Schema.Types.ObjectId,
-  name: String,
-  userName: String,
-  profileImg: String,
-});
+const followSchema = new mongoose.Schema(
+  {
+    userId: mongoose.Schema.Types.ObjectId,
+    name: String,
+    userName: String,
+    profileImg: String,
+  },
+  { _id: false },
+);
 
 const userSchema = new mongoose.Schema({
   name: String,
@@ -48,9 +51,9 @@ userSchema.methods.findUserName = async function findUserName() {
 };
 
 export interface IFollow {
-  userId?: mongoose.Schema.Types.ObjectId;
+  userId: mongoose.Schema.Types.ObjectId;
   name?: string;
-  userName?: string;
+  userName: string;
   profileImg?: string;
 }
 
@@ -106,28 +109,29 @@ userSchema.methods.deleteFollow = async function deletefollow(
   user: IFollow,
   target: IFollow,
 ) {
-  const result =
-    (await mongoose.model('User').updateOne(
-      { _id: user.userId },
-      {
-        $pull: {
-          follow: {
-            userId: target.userId,
-          },
+  console.log(target);
+  console.log(user);
+  const result = await mongoose.model('User').updateOne(
+    { _id: user.userId },
+    {
+      $pull: {
+        follow: {
+          userId: target.userId,
         },
       },
-    )) &&
-    (await mongoose.model('User').updateOne(
-      { _id: target.userId },
-      {
-        $pull: {
-          follower: {
-            userId: user.userId,
-          },
+    },
+  );
+  const result1 = await mongoose.model('User').updateOne(
+    { _id: target.userId },
+    {
+      $pull: {
+        follower: {
+          userId: user.userId,
         },
       },
-    ));
-  return result;
+    },
+  );
+  return result && result1;
 };
 
 export interface IUser extends mongoose.Document {

--- a/server/src/routes/user.router.ts
+++ b/server/src/routes/user.router.ts
@@ -1,8 +1,11 @@
 import express from 'express';
 import UserController from '../controllers/user.controller';
+import validation from '../passport/validation';
 
 const router = express.Router();
 
 router.get('/profile/:userName', UserController.getProfile);
+
+router.post('/follow/:userName', validation, UserController.follow);
 
 export default router;

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -1,5 +1,5 @@
 import FeedModel from '../models/feed.model';
-import UserModel from '../models/user.model';
+import UserModel, { IFollow } from '../models/user.model';
 
 const getProfile = async (userName: string): Promise<any> => {
   const user = new UserModel({ userName });
@@ -11,4 +11,25 @@ const getProfile = async (userName: string): Promise<any> => {
   return { userInfo, feeds };
 };
 
-export default getProfile;
+const follow = async (
+  params: IFollow,
+  targetName: string,
+  status: number,
+): Promise<boolean> => {
+  const user = new UserModel({ userName: targetName });
+  const userInfo = await user.findUserName();
+  const target = {
+    userId: userInfo._id,
+    userName: userInfo.userName,
+    name: userInfo.name ? userInfo.name : '',
+    profileImg: userInfo.profileImg,
+  };
+  const liked = 1;
+  const result =
+    status === liked
+      ? await user.createFollow(params, target)
+      : await user.deleteFollow(params, target);
+  return result;
+};
+
+export { getProfile, follow };


### PR DESCRIPTION
#135 

### 내용
- 팔로우 / 팔로워 api 구현
  - api 경로 : /user/follow/:userName
  - target user name을 파라미터로 전달
  - body 값 : author, status
  - author는 name, username, profileImg
  - status 1: 팔로우 요청 0: 언팔로우 요청
  - followSchema에 _id: false 옵션 추가
- 팔로우 / 팔로워 api 클라이언트 연결
  - 팔로우 / 팔로워 api 연결
  - useState 사용으로 언팔로우시 팔로워 수 -1 / 팔로우시 팔로워 수 +1
  - useState 사용으로 팔로우 / 팔로워 버튼 동작 시 전환

### 체크리스트
- [x] dev 브랜치가 맞는가?
- [ ] issue를 잘 닫았는가?
- [ ] reviewer, assignee, label 등록을 했는가?
