### PR TITLE
feat: 홈 화면 링크 기능 추가 및 css 수정

### DIFF
--- a/client/src/components/home/presentational/Comment.js
+++ b/client/src/components/home/presentational/Comment.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import UserName from '@home/presentational/UserName';
+import { Link } from 'react-router-dom';
 
 const style = {};
 
@@ -16,11 +17,20 @@ style.Content = styled.div`
   text-overflow: ellipsis;
 `;
 
+style.Link = styled(Link)`
+  text-decoration: none;
+`;
+
 const Comment = (input) => {
   const { author, content } = input;
+  const { userName } = author;
+  const href = `/profile?userName=${userName}`;
+
   return (
     <style.Comment>
-      <UserName>{author.userName}</UserName>
+      <style.Link to={href}>
+        <UserName>{userName}</UserName>
+      </style.Link>
       <style.Content>{content}</style.Content>
     </style.Comment>
   );

--- a/client/src/components/home/presentational/FeedItemAuthor.js
+++ b/client/src/components/home/presentational/FeedItemAuthor.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import UserName from '@home/presentational/UserName';
+import { Link } from 'react-router-dom';
 
 const style = {};
 
@@ -8,12 +9,17 @@ style.UserInfo = styled.div`
   display: flex;
   width: 100%;
   height: 60px;
+  cursor: pointer;
+`;
+
+style.Link = styled(Link)`
+  margin: auto 0;
+  text-decoration: none;
 `;
 
 style.UserProfileImg = styled.img`
   width: 32px;
   height: 32px;
-  margin: auto 0;
   margin-left: 16px;
   border-radius: 70%;
   cursor: pointer;
@@ -21,10 +27,17 @@ style.UserProfileImg = styled.img`
 
 const FeedItemAuthor = (input) => {
   const { author } = input;
+  const { userName, profileImg } = author;
+  const href = `/profile?userName=${userName}`;
+
   return (
     <style.UserInfo>
-      <style.UserProfileImg src={author.profileImg} />
-      <UserName>{author.userName}</UserName>
+      <style.Link to={href}>
+        <style.UserProfileImg src={profileImg} />
+      </style.Link>
+      <style.Link to={href}>
+        <UserName>{userName}</UserName>
+      </style.Link>
     </style.UserInfo>
   );
 };

--- a/client/src/components/home/presentational/FeedItemImg.js
+++ b/client/src/components/home/presentational/FeedItemImg.js
@@ -22,6 +22,7 @@ style.PreButton = styled.button`
   height: 30px;
   cursor: pointer;
   outline: none;
+  margin-left: 15px;
 `;
 style.NextButton = styled.button`
   display: ${(props) => (props.length - 1 === props.index ? 'none' : 'block')};
@@ -37,6 +38,7 @@ style.NextButton = styled.button`
   margin-left: auto;
   z-index: 1;
   outline: none;
+  margin-right: 15px;
 `;
 
 style.feedImg = styled.img`

--- a/client/src/components/home/presentational/UserName.js
+++ b/client/src/components/home/presentational/UserName.js
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 const UserName = styled.div`
   width: auto;
-  margin: auto 0;
   margin-left: 16px;
   font-weight: 600;
   font-size: 14px;


### PR DESCRIPTION
### 내용
- 홈 화면에서 게시물 작성자 아이디 및 프로필 이미지 클릭으로 해당 유저의 프로필 화면으로 이동 기능 추가
- 댓글 작성자 아이디 클릭으로 해당 유저의 프로필 화면으로 이동 기능 추가
- 홈 화면 게시물 스왑 버튼 margin 추가

### 체크리스트
- [ ] dev 브랜치가 맞는가?
- [ ] issue를 잘 닫았는가?
- [ ] reviewer, assignee, label 등록을 했는가?
