### PR TITLE
홈 팔로우 목록 부분 수정 및 팔로우 클릭 기능 추가

### DIFF
--- a/client/src/components/common/Header.js
+++ b/client/src/components/common/Header.js
@@ -69,9 +69,6 @@ const Header = ({ handleModal }) => {
               <icon.NewFeed />
             </style.newFeedButton>
           )}
-          <style.NavigationItem to={pathURI.HOME}>
-            <icon.Direct />
-          </style.NavigationItem>
           <style.NavigationItem to={pathURI.EXPLORE}>
             <icon.Explore />
           </style.NavigationItem>

--- a/client/src/components/feedDetail/presentational/AuthorProfile.js
+++ b/client/src/components/feedDetail/presentational/AuthorProfile.js
@@ -94,7 +94,7 @@ const AuthorProfile = ({ author }) => {
         setLogin({ ...login, follow: newFollow });
       } else {
         const newFollow = login.follow;
-        newFollow.push({ userName });
+        newFollow.push({ userName, profileImg });
         setLogin({ ...login, follow: newFollow });
       }
 

--- a/client/src/components/home/presentational/Contents.js
+++ b/client/src/components/home/presentational/Contents.js
@@ -30,11 +30,10 @@ const Contents = (input) => {
   if (login.follow === undefined) {
     return <></>;
   }
-  console.log(login);
 
   return (
     <style.Contents>
-      <Story datas={login.follow ? login.follow : []} />
+      <Story datas={login.follow} />
       <Feed data={data} setGetMore={setGetMore} />
       {data.length === 0 ? (
         <>

--- a/client/src/components/home/presentational/Contents.js
+++ b/client/src/components/home/presentational/Contents.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import Story from '@home/presentational/Story';
 import Feed from '@home/presentational/Feed';
 import icon from '@constants/icon';
+import UserContext from '@context/user';
 
 const style = {};
 
@@ -25,9 +26,15 @@ style.GuideMessage = styled.div`
 
 const Contents = (input) => {
   const { data, setGetMore } = input;
+  const { login } = useContext(UserContext);
+  if (login.follow === undefined) {
+    return <></>;
+  }
+  console.log(login);
+
   return (
     <style.Contents>
-      <Story datas={data} />
+      <Story datas={login.follow ? login.follow : []} />
       <Feed data={data} setGetMore={setGetMore} />
       {data.length === 0 ? (
         <>

--- a/client/src/components/home/presentational/Story.js
+++ b/client/src/components/home/presentational/Story.js
@@ -29,12 +29,16 @@ const Story = (input) => {
   const user = [];
   return (
     <style.Story datas={datas}>
-      {datas.map((data) => {
-        if (!user.includes(data.author.userId)) {
-          user.push(data.author.userId);
-          return <StoryItems key={data.author.userId} data={data} />;
-        }
-      })}
+      {datas.length > 0 ? (
+        datas.map((data) => {
+          if (!user.includes(data.userId)) {
+            user.push(data.userId);
+            return <StoryItems key={data.userId} data={data} />;
+          }
+        })
+      ) : (
+        <></>
+      )}
     </style.Story>
   );
 };

--- a/client/src/components/home/presentational/Story.js
+++ b/client/src/components/home/presentational/Story.js
@@ -29,16 +29,12 @@ const Story = (input) => {
   const user = [];
   return (
     <style.Story datas={datas}>
-      {datas.length > 0 ? (
-        datas.map((data) => {
-          if (!user.includes(data.userId)) {
-            user.push(data.userId);
-            return <StoryItems key={data.userId} data={data} />;
-          }
-        })
-      ) : (
-        <></>
-      )}
+      {datas.map((data) => {
+        if (!user.includes(data.userId)) {
+          user.push(data.userId);
+          return <StoryItems key={data.userId} data={data} />;
+        }
+      })}
     </style.Story>
   );
 };

--- a/client/src/components/home/presentational/StoryItems.js
+++ b/client/src/components/home/presentational/StoryItems.js
@@ -28,15 +28,15 @@ style.UserName = styled.div`
 `;
 
 const StoryItems = (input) => {
-  const { author } = input.data;
+  const { profileImg, userName } = input.data;
   const onClick = () => {
     // todo: 모달창
   };
   return (
     <>
       <style.StoryItems>
-        <style.Item src={author.profileImg} onClick={onClick} />
-        <style.UserName>{author.userName}</style.UserName>
+        <style.Item src={profileImg} onClick={onClick} />
+        <style.UserName>{userName}</style.UserName>
       </style.StoryItems>
     </>
   );

--- a/client/src/components/home/presentational/StoryItems.js
+++ b/client/src/components/home/presentational/StoryItems.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 const style = {};
 
-style.StoryItems = styled.div`
+style.StoryItems = styled(Link)`
   width: 66px;
   height: auto;
   margin-left: 10px;
   padding: 0px 4px;
   cursor: pointer;
+  text-decoration: none;
 `;
 
 style.Item = styled.img`
@@ -29,12 +31,13 @@ style.UserName = styled.div`
 
 const StoryItems = (input) => {
   const { profileImg, userName } = input.data;
+  const userProfileURL = `/profile?userName=${userName}`;
   const onClick = () => {
     // todo: 모달창
   };
   return (
     <>
-      <style.StoryItems>
+      <style.StoryItems to={userProfileURL}>
         <style.Item src={profileImg} onClick={onClick} />
         <style.UserName>{userName}</style.UserName>
       </style.StoryItems>

--- a/client/src/components/profile/presentational/ProfileInfo.js
+++ b/client/src/components/profile/presentational/ProfileInfo.js
@@ -164,7 +164,10 @@ const ProfileInfo = (input) => {
           );
           setLogin({ ...login, follow: newFollow });
         } else {
-          login.follow.push({ userName: userInfo.userName });
+          login.follow.push({
+            userName: userInfo.userName,
+            profileImg: userInfo.profileImg,
+          });
           setLogin({ ...login });
         }
         setFollowerNumState(followStatus ? followerNum - 1 : followerNum + 1);


### PR DESCRIPTION
### 내용
- home 상단 팔로우 리스트 수정
  - home 상단에 팔로우 리스트 수정
  - 기존에 feed author 목록 출력에서 로그인 한 사용자의 팔로우 목록 출력으로 수정
- DM 아이콘 제거
- 팔로우 목록 클릭 기능 추가
  - 홈 화면에서 팔로우 목록의 유저 이미지 또는 아이디 클릭 시 해당 유저의 프로필 화면으로 전환 기능 추가



### 체크리스트
- [ ] dev 브랜치가 맞는가?
- [ ] issue를 잘 닫았는가?
- [ ] reviewer, assignee, label 등록을 했는가?
